### PR TITLE
Fix line break problem in plugin header example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This meta-plugin allows regular plugins to specify other plugins that they depen
 
 Example:
 
-`
+```
 /*
 Plugin Name: BuddyPress Debug
 Depends: BuddyPress, Debug Bar
 */
-`
+```
 
 What this does:
 


### PR DESCRIPTION
In prose, GitHub Markdown only honors linebreaks if line ends in double spaces. This doesn't apply in a code block.
