### PR TITLE
Generate readme.md from readme.txt via generate-markdown-readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Besides being more robust, the *Provides:* header allows multiple plugins to imp
 ## Changelog ##
 
 ### 1.2.1 ###
-* fixed notices. props cfoellmann
+* fixed notices. props [cfoellmann](http://profiles.wordpress.org/cfoellmann)
 
 ### 1.2 ###
 * added ability to use plugin names as dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,7 @@ Besides being more robust, the *Provides:* header allows multiple plugins to imp
 == Changelog ==
 
 = 1.2.1 =
-* fixed notices. props cfoellmann
+* fixed notices. props [cfoellmann](http://profiles.wordpress.org/cfoellmann)
 
 = 1.2 =
 * added ability to use plugin names as dependencies


### PR DESCRIPTION
Move existing `README.md` to `readme.txt` and format according to the WordPress.org README standard. The `readme.md` can then be auto-generated via [generate-markdown-readme](https://github.com/x-team/wp-plugin-dev-lib/blob/master/generate-markdown-readme).

Depends on #13
