### PR TITLE
Change the tint of green used for satisfied and add title attributes

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -282,7 +282,7 @@ class Plugin_Dependencies_UI {
 				.dep-list li { list-style: disc inside none }
 				span.deps li.unsatisfied { color: red }
 				span.deps li.unsatisfied_network { color: orange }
-				span.deps li.satisfied { color: green }
+				span.deps li.satisfied { color: lime }
 			</style>
 		<?php
 	}
@@ -358,12 +358,15 @@ class Plugin_Dependencies_UI {
 			$plugin_ids = Plugin_Dependencies::get_providers( $dep );
 			if ( in_array( $dep, $unsatisfied ) ) {
 				$class = 'unsatisfied';
+				$title = __( 'Unsatisfied', 'plugin-dependencies' );
 			}
 			elseif ( in_array( $dep, $unsatisfied_network ) ) {
 				$class = 'unsatisfied_network';
+				$title = __( 'Network unsatisfied', 'plugin-dependencies' );
 			}
 			else {
 				$class = 'satisfied';
+				$title = __( 'Satisfied', 'plugin-dependencies' );
 			}
 
 			if ( empty( $plugin_ids ) ) {
@@ -385,7 +388,7 @@ class Plugin_Dependencies_UI {
 						$name = $plugin_id;
 						$url  = '#' . sanitize_title( $name );
 					}
-					$list[] = html( 'a', array( 'href' => $url ), $name );
+					$list[] = html( 'a', array( 'href' => $url, 'title' => $title ), $name );
 				}
 				$name = implode( ' or ', $list );
 			}


### PR DESCRIPTION
On some displays the darker green in combination with the blue text around it will look blue-ish, rather than the more telling green.
The `lime` color keyword is widely supported and a clearer green indicator in this case.

This doesn't take away from the fact that indicators based on color with no other indicator _will_ give issues for people with color blindness, no matter what.
So to improve usability, I've added a title attribute to the links in the list items indicating the status.
