### PR TITLE
Make `generate_dep_list()` public

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -349,7 +349,7 @@ class Plugin_Dependencies_UI {
 		return $actions;
 	}
 
-	private static function generate_dep_list( $deps, $unsatisfied = array(), $unsatisfied_network = array() ) {
+	public static function generate_dep_list( $deps, $unsatisfied = array(), $unsatisfied_network = array() ) {
 		$all_plugins = get_plugins();
 		$mu_plugins  = get_mu_plugins();
 


### PR DESCRIPTION
Useful for if you have a custom plugins page in which you'd like to show dependencies as well
