### PR TITLE
Simplify the css & non-breaking text

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -280,9 +280,9 @@ class Plugin_Dependencies_UI {
 		?>
 			<style type="text/css">
 				.dep-list li { list-style: disc inside none }
-				span.deps li.unsatisfied { color: red }
-				span.deps li.unsatisfied_network { color: orange }
-				span.deps li.satisfied { color: lime }
+				.dep-list li.unsatisfied { color: red }
+				.dep-list li.unsatisfied_network { color: orange }
+				.dep-list li.satisfied { color: lime }
 			</style>
 		<?php
 	}
@@ -344,7 +344,7 @@ class Plugin_Dependencies_UI {
 			unset( $actions['network_activate'] );
 		}
 
-		$actions['deps'] = __( 'Required plugins:', 'plugin-dependencies' ) . '<br>' . self::generate_dep_list( $deps, $unsatisfied, $unsatisfied_network );
+		$actions['deps'] = str_replace( ' ', '&nbsp;', __( 'Required plugins:', 'plugin-dependencies' ) ) . '<br>' . self::generate_dep_list( $deps, $unsatisfied, $unsatisfied_network );
 
 		return $actions;
 	}

--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -279,6 +279,7 @@ class Plugin_Dependencies_UI {
 	public static function admin_print_styles() {
 		?>
 			<style type="text/css">
+				span.dep-action { white-space: nowrap }
 				.dep-list li { list-style: disc inside none }
 				.dep-list li.unsatisfied { color: red }
 				.dep-list li.unsatisfied_network { color: orange }
@@ -344,7 +345,7 @@ class Plugin_Dependencies_UI {
 			unset( $actions['network_activate'] );
 		}
 
-		$actions['deps'] = str_replace( ' ', '&nbsp;', __( 'Required plugins:', 'plugin-dependencies' ) ) . '<br>' . self::generate_dep_list( $deps, $unsatisfied, $unsatisfied_network );
+		$actions['deps'] = html( 'span', array( 'class' => 'dep-action' ), __( 'Required plugins:', 'plugin-dependencies' ) ) . '<br>' . self::generate_dep_list( $deps, $unsatisfied, $unsatisfied_network );
 
 		return $actions;
 	}


### PR DESCRIPTION
- make the css color coding independent of list-table context
- prevent the 'Required plugins' phrase wrapping across lines
