### PR TITLE
Allow other plugins to provide plugin data too

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -61,6 +61,7 @@ class Plugin_Dependencies {
 
 	public static function init() {
 		$all_plugins = array_merge(
+			apply_filters( 'plugin_dependencies_provider', array() ),
 			get_plugins(),
 			get_mu_plugins()
 		);

--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -60,11 +60,8 @@ class Plugin_Dependencies {
 	private static $deactivate_conflicting;
 
 	public static function init() {
-		$all_plugins = array_merge(
-			apply_filters( 'plugin_dependencies_provider', array() ),
-			get_plugins(),
-			get_mu_plugins()
-		);
+		$all_plugins = array_merge( get_plugins(), get_mu_plugins() );
+		$all_plugins = apply_filters( 'plugin_dependencies_all_plugins', $all_plugins );
 
 		$plugins_by_name = array();
 		foreach ( $all_plugins as $plugin => $plugin_data ) {


### PR DESCRIPTION
The filter should return an array, this could be an empty array or an array containing as a minimum the below for each plugin, obviously with data for the provides/depends key where applicable:

``` php
array(
    'plugin-dir/file.php' => array(
        'Name' => 'Plugin name',
        'Provides' => '',
        'Depends' => '',
    )
)
```
