### PR TITLE
Use pre[lang] tags for code blocks in readme.txt for convetsion to GitHub Markdown code blocks

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -666,7 +666,7 @@ class Plugin_Dependencies_UI {
 						$self.attr('id', hash[title]);
 					});
 		<?php
-		if ( is_multisite() && ! is_network_admin() ):
+		if ( is_multisite() && ! is_network_admin() ) :
 			?>
 					$('<?php echo esc_attr( $unsatisfied ); ?>').remove();
 			<?php

--- a/readme.md
+++ b/readme.md
@@ -18,12 +18,12 @@ This meta-plugin allows regular plugins to specify other plugins that they depen
 
 Example:
 
-`
+```php
 /*
 Plugin Name: BuddyPress Debug
 Depends: BuddyPress, Debug Bar
 */
-`
+```
 
 What this does:
 
@@ -48,21 +48,21 @@ Yes, the dependency chain can go as deep as you want.
 ### Defining virtual packages ###
 Say you have some useful functions that you would like to package up as a library plugin:
 
-`
+```php
 /*
 Plugin Name: Facebook Lib
 Provides: lib-facebook
 */
-`
+```
 
 Now, dependant plugins can specify 'lib-facebook' as a dependency:
 
-`
+```php
 /*
 Plugin Name: Cool Facebook Plugin
 Depends: lib-facebook
 */
-`
+```
 
 Besides being more robust, the *Provides:* header allows multiple plugins to implement the same set of functionality and be used interchangeably.
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,12 +15,12 @@ This meta-plugin allows regular plugins to specify other plugins that they depen
 
 Example:
 
-`
+<pre lang="php">
 /*
 Plugin Name: BuddyPress Debug
 Depends: BuddyPress, Debug Bar
 */
-`
+</pre>
 
 What this does:
 
@@ -48,21 +48,21 @@ Yes, the dependency chain can go as deep as you want.
 
 Say you have some useful functions that you would like to package up as a library plugin:
 
-`
+<pre lang="php">
 /*
 Plugin Name: Facebook Lib
 Provides: lib-facebook
 */
-`
+</pre>
 
 Now, dependant plugins can specify 'lib-facebook' as a dependency:
 
-`
+<pre lang="php">
 /*
 Plugin Name: Cool Facebook Plugin
 Depends: lib-facebook
 */
-`
+</pre>
 
 Besides being more robust, the *Provides:* header allows multiple plugins to implement the same set of functionality and be used interchangeably.
 


### PR DESCRIPTION
Uses https://github.com/xwp/wp-dev-lib/pull/68 for https://github.com/xwp/wp-dev-lib/issues/67
