### PR TITLE
Fix duplicate plugin's basename

### DIFF
--- a/plugin-dependencies.php
+++ b/plugin-dependencies.php
@@ -202,7 +202,7 @@ class Plugin_Dependencies {
 			$bulk = $_POST['checked'];
 		}
 
-		self::$active_plugins = array_merge( self::$active_plugins, array_keys( (array) get_mu_plugins() ), $bulk );
+		self::$active_plugins = array_unique( array_merge( self::$active_plugins, array_keys( (array) get_mu_plugins() ), $bulk ) );
 
 		$deps = self::get_dependencies( $plugin );
 		if ( count( $deps ) === count( array_intersect( self::$active_plugins, $deps ) ) ) {


### PR DESCRIPTION
I tried to activate a plugin (plugin1) on a site which depend on another plugin (plugin2) who is activated on the network. The plugin2 has been activated on a specific site and then activated network wide.

Whenever I tried to activate plugin1, the activation failed with Plugin dependencies telling me that the requirements was not met. It turn out that during the activation check self::$active_plugins contained the plugin2's basename twice (because of the double activation on a site and network wide).

Removing duplicates with array_unique in self::$active_plugins in check_activation fix the issue.
